### PR TITLE
test for saga handling same message type in startsSaga and eventHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ target/
 .idea
 *.iml
 .DS_Store
+
+# eclipse
+.settings
+.project
+.classpath

--- a/saga-lib/src/test/java/com/codebullets/sagalib/handling/SameMessageIntegrationTest.java
+++ b/saga-lib/src/test/java/com/codebullets/sagalib/handling/SameMessageIntegrationTest.java
@@ -1,0 +1,92 @@
+/*
+ * COPYRIGHT: FREQUENTIS AG. All rights reserved.
+ *            Registered with Commercial Court Vienna,
+ *            reg.no. FN 72.115b.
+ */
+package com.codebullets.sagalib.handling;
+
+import com.codebullets.sagalib.MessageStream;
+import com.codebullets.sagalib.Saga;
+import com.codebullets.sagalib.processing.SagaProviderFactory;
+import com.codebullets.sagalib.startup.EventStreamBuilder;
+import com.codebullets.sagalib.startup.TypeScanner;
+import com.google.common.collect.ImmutableList;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.inject.Provider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class SameMessageIntegrationTest {
+    private AtomicInteger startCounter;
+    private AtomicInteger continueCounter;
+
+    private MessageStream messageStream;
+
+    @BeforeEach
+    void initSameMessageIntegrationTes() {
+        startCounter = new AtomicInteger(0);
+        continueCounter = new AtomicInteger(0);
+
+        messageStream = EventStreamBuilder.configure()
+                .usingScanner(provideTypes())
+                .usingSagaProviderFactory(providerFactory())
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (messageStream != null) {
+            messageStream.close();
+        }
+    }
+
+    @RepeatedTest(value = 100)
+    void handle_startMessage_shallCallStartsSagaMethod() throws InvocationTargetException, IllegalAccessException {
+        // given
+        StartMessage theMessage = new StartMessage("instance key");
+
+        // when
+        messageStream.handle(theMessage);
+
+        // then
+        assertThat("Expected startsSaga to be called.", startCounter.get(), equalTo(1));
+        assertThat("Expected continuesSaga not to be called.", continueCounter.get(), equalTo(0));
+    }
+
+    @RepeatedTest(value = 100)
+    void handle_startMessageTwice_continuesExistingSagaAndStartsNewOne() throws InvocationTargetException, IllegalAccessException {
+        // given
+        StartMessage theMessage = new StartMessage("instance key");
+
+        // when
+        messageStream.handle(theMessage);
+        messageStream.handle(theMessage);
+
+        // then
+        assertThat("Expected startsSaga to be called twice.", startCounter.get(), equalTo(2));
+        assertThat("Expected continuesSaga to be called once.", continueCounter.get(), equalTo(1));
+    }
+
+    private TypeScanner provideTypes() {
+        return () -> ImmutableList.of(SameMessageSaga.class);
+    }
+
+    private SagaProviderFactory providerFactory() {
+        return new SagaProviderFactory() {
+            @Override
+            public <T extends Saga> Provider<T> createProvider(final Class<T> sagaClass) {
+                Provider<T> provider = null;
+                if (sagaClass.equals(SameMessageSaga.class)) {
+                    provider = (Provider) () -> new SameMessageSaga(startCounter, continueCounter);
+                }
+
+                return provider;
+            }
+        };
+    }
+}

--- a/saga-lib/src/test/java/com/codebullets/sagalib/handling/SameMessageSaga.java
+++ b/saga-lib/src/test/java/com/codebullets/sagalib/handling/SameMessageSaga.java
@@ -8,10 +8,11 @@ package com.codebullets.sagalib.handling;
 import com.codebullets.sagalib.AbstractSaga;
 import com.codebullets.sagalib.EventHandler;
 import com.codebullets.sagalib.KeyReader;
+import com.codebullets.sagalib.KeyReaders;
 import com.codebullets.sagalib.StartsSaga;
 import com.codebullets.sagalib.TestSagaState;
+import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class SameMessageSaga extends AbstractSaga<TestSagaState> {
@@ -42,6 +43,7 @@ public class SameMessageSaga extends AbstractSaga<TestSagaState> {
 
     @Override
     public Collection<KeyReader> keyReaders() {
-        return Collections.emptyList();
+        return ImmutableSet.of(
+                KeyReaders.forMessage(StartMessage.class, StartMessage::getInstanceKey));
     }
 }

--- a/saga-lib/src/test/java/com/codebullets/sagalib/handling/SameMessageSaga.java
+++ b/saga-lib/src/test/java/com/codebullets/sagalib/handling/SameMessageSaga.java
@@ -1,0 +1,47 @@
+/*
+ * COPYRIGHT: FREQUENTIS AG. All rights reserved.
+ *            Registered with Commercial Court Vienna,
+ *            reg.no. FN 72.115b.
+ */
+package com.codebullets.sagalib.handling;
+
+import com.codebullets.sagalib.AbstractSaga;
+import com.codebullets.sagalib.EventHandler;
+import com.codebullets.sagalib.KeyReader;
+import com.codebullets.sagalib.StartsSaga;
+import com.codebullets.sagalib.TestSagaState;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SameMessageSaga extends AbstractSaga<TestSagaState> {
+    private final AtomicInteger startCounter;
+    private final AtomicInteger continueCounter;
+
+    public SameMessageSaga(final AtomicInteger startCounter, final AtomicInteger continueCounter) {
+        this.startCounter = startCounter;
+        this.continueCounter = continueCounter;
+    }
+
+    @StartsSaga
+    public void sagaStartup(final StartMessage startMessage) {
+        state().addInstanceKey(startMessage.getInstanceKey());
+        startCounter.incrementAndGet();
+    }
+
+    @EventHandler
+    public void continuesSaga(final StartMessage message) {
+        continueCounter.incrementAndGet();
+        setFinished();
+    }
+
+    @Override
+    public void createNewState() {
+        setState(new TestSagaState());
+    }
+
+    @Override
+    public Collection<KeyReader> keyReaders() {
+        return Collections.emptyList();
+    }
+}

--- a/saga-lib/src/test/java/com/codebullets/sagalib/handling/StartMessage.java
+++ b/saga-lib/src/test/java/com/codebullets/sagalib/handling/StartMessage.java
@@ -1,0 +1,25 @@
+/*
+ * COPYRIGHT: FREQUENTIS AG. All rights reserved.
+ *            Registered with Commercial Court Vienna,
+ *            reg.no. FN 72.115b.
+ */
+package com.codebullets.sagalib.handling;
+
+public class StartMessage {
+    private String instanceKey;
+
+    public StartMessage() {
+    }
+
+    public StartMessage(final String instanceKey) {
+        this.instanceKey = instanceKey;
+    }
+
+    public String getInstanceKey() {
+        return instanceKey;
+    }
+
+    public void setInstanceKey(final String instanceKey) {
+        this.instanceKey = instanceKey;
+    }
+}

--- a/saga-lib/src/test/java/com/codebullets/sagalib/handling/StartMessage.java
+++ b/saga-lib/src/test/java/com/codebullets/sagalib/handling/StartMessage.java
@@ -8,9 +8,6 @@ package com.codebullets.sagalib.handling;
 public class StartMessage {
     private String instanceKey;
 
-    public StartMessage() {
-    }
-
     public StartMessage(final String instanceKey) {
         this.instanceKey = instanceKey;
     }


### PR DESCRIPTION
Hi Domo,
this is not intended for merging. Just for discussion.

We have the following use case, that a notification shall start a new saga and triggers a complex workflow which keeps the saga alive. In case a notification of same type and instance key is received the saga shall be resumed and finished (aka workflow aborted). Also a new saga shall be started to trigger the same complex workflow with the new information.

I checked the ReflectionInvoker and realized that if a saga handles the same message type within a startsSaga and an eventHandler then it is not deterministic which of these handlers is executed. sometimes the startsSaga is called and sometimes the event handler. (see test "handle_startMessage_shallCallStartsSagaMethod") This seems to result from the HandlerInvoker Api only allow to pass a saga and the message type. The needed information to distinguish between a starting and continue method is available in the SagaInstanceInfo. Would it be possible to extend HandlerInvoker to process SagaInstanceInfo and message type to enable the described workflow?

KR Olivia